### PR TITLE
some entities were omited in AutorouteListener::onFlush

### DIFF
--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -15,7 +15,7 @@
         <!--todo este servicio está acoplado a wam/wam/routingBundle por el enhancer-->
         <service id="cmf_routing_auto.adapter.orm" class="%cmf_routing_auto.adapter.orm.class%">
             <argument type="service" id="doctrine.orm.entity_manager"/>
-            <argument type="service" id="wam.routing.content.router_enhancer"/>
+            <argument type="service" id="wam_routing.content.router_enhancer"/>
             <argument>%cmf_routing.auto_route_entity.class%</argument>
         </service>
 


### PR DESCRIPTION
cambios:
- en el caso de persistir, por ejemplo, translatableEntity y translatableEntityTranslation a la vez, la primera se omitía en el tryGetAutoRouteable
- ahora CommitCalculator se usa de una forma más inteligente, sólo cuando se necesita. Creo que así se evita el error de undefined index que daba a veces. Sospecho que ese error venía por meter entidades en la calculadora que no se iban a commitear
- refactor en el nombre de servicios de wam_routing
