### PR TITLE
Use microtime() instead of time() in route name prefix for avoiding b…

### DIFF
--- a/src/Adapter/OrmAdapter.php
+++ b/src/Adapter/OrmAdapter.php
@@ -165,7 +165,7 @@ class OrmAdapter implements AdapterInterface
             $routeNameParts[] = $autoRouteTag;
         }
 
-        $routeNameParts[] = time();
+        $routeNameParts[] = str_replace('.', '', microtime(true));
         $headRoute->setName(implode('_', $routeNameParts));
 
         return $headRoute;


### PR DESCRIPTION
…ug when several routes are created at the same second